### PR TITLE
new file "pyproject.toml" to support creating a pip-installable whl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+[project]
+name = "jl95terceira_msoffice"
+version = "0.1.0"
+authors = [
+  { name="Joao Luis" },
+]
+description = "Microsoft Office file read / write API"
+readme = "README.md"
+requires-python = ">=3.12"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/jl95terceira/project-B"
+Issues = "https://github.com/jl95terceira/project-B/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["project_package/package"]
+
+[tool.hatch.build.targets.wheel.sources]
+"project_package/package" = "jl95terceira_msoffice"


### PR DESCRIPTION
with calling "python -m build"
(requires pip-installing "build" and "hatch" beforehand)
TODO: update README accordingly